### PR TITLE
size option in svlogd config file uses wrong case

### DIFF
--- a/templates/default/config.svlogd
+++ b/templates/default/config.svlogd
@@ -1,3 +1,3 @@
 # svlogd configuration
-S<%= @svlogd_size %>
+s<%= @svlogd_size %>
 n<%= @svlogd_num %>


### PR DESCRIPTION
The option "S"<size> is incorrect and will be ignored by svlogd.  Changed to "s" per man page.

