### PR TITLE
Ubuntu (upstart) / Debian (sysvinit) split

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,36 @@
-# 0.4.4 - 2014-07-18
-- [OC-11575] Don't start services by default in HA topology
+## Enterprise Cookbook Change Log
 
-# 0.4.3 - 2014-05-27
-- unbreak runit setup on sysv style init (RHEL5)
+## 0.5.2 (2015-02-05)
 
-# 0.4.2 - 2014-05-13
-- Enable a cluster's default encoding to be specified
+* Add svlogd bin attribute for runit
+
+## 0.5.1 (2015-01-15)
+
+* Make it possible to pass arbitrary attrs to runit resources
+* Add systemd support
+
+## 0.4.7 (2014-11-19)
+
+* Reload logging service on config changes
+
+## 0.4.6 (2014-11-06)
+
+* Apply Apache 2.0 license
+* Allow project to override the name of the ctl script
+
+## 0.4.5 (2014-09-03)
+
+* Unbreak private-chef package upgrades, since package\_name of private\_chef causes major issues
+* Don't mess with `install_path` and also don't mess with `node['enterprise']['name']` downstream by cloning it
+
+## 0.4.4 (2014-07-18)
+
+* [OC-11575] Don't start services by default in HA topology
+
+## 0.4.3 (2014-05-27)
+
+* Unbreak runit setup on sysv style init (RHEL5)
+
+## 0.4.2 (2014-05-13)
+
+* Enable a cluster's default encoding to be specified

--- a/metadata.rb
+++ b/metadata.rb
@@ -2,6 +2,6 @@ name             'enterprise'
 license          'All rights reserved'
 description      'Installs common libraries and resources for Enterprise Chef and closed-source additions'
 long_description 'Installs common libraries and resources for Enterprise Chef and closed-source additions'
-version          '0.5.1'
+version          '0.5.2'
 
 depends          'runit', '> 1.0.0'

--- a/metadata.rb
+++ b/metadata.rb
@@ -2,6 +2,6 @@ name             'enterprise'
 license          'All rights reserved'
 description      'Installs common libraries and resources for Enterprise Chef and closed-source additions'
 long_description 'Installs common libraries and resources for Enterprise Chef and closed-source additions'
-version          '0.5.0'
+version          '0.5.1'
 
 depends          'runit', '> 1.0.0'

--- a/recipes/runit.rb
+++ b/recipes/runit.rb
@@ -19,7 +19,12 @@ if node['init_package'] == 'systemd'
 else
   case node['platform_family']
   when 'debian'
-    include_recipe 'enterprise::runit_upstart'
+    case node['platform']
+    when 'debian'
+      include_recipe 'enterprise::runit_sysvinit'
+    else
+      include_recipe 'enterprise::runit_upstart'
+    end
   when 'fedora', 'rhel'
     case node['platform']
     when 'amazon', 'fedora'

--- a/spec/recipes/runit_spec.rb
+++ b/spec/recipes/runit_spec.rb
@@ -28,8 +28,8 @@ describe 'enterprise::runit' do
   context 'when on Debian' do
     let(:runner) { ChefSpec::Runner.new(platform: 'debian', version: '7.4') }
 
-    it 'includes the runit_upstart recipe' do
-      expect(chef_run).to include_recipe 'enterprise::runit_upstart'
+    it 'includes the runit_sysvinit recipe' do
+      expect(chef_run).to include_recipe 'enterprise::runit_sysvinit'
     end
   end
 


### PR DESCRIPTION
Even is Chef Server 12 is not officially supported on Debian, the Ubuntu 11.04 packages (glibc compatible) work perfectly after applying this PR's changes.

I just introduced an additional test on `platform` to split the Ubuntu and Debian cases. Of course, some more check could be added once Debian "Jessie" (with systemd) is out.

And yes, it's possible to switch from sysV to Upstart on Debian Wheezy. But while sysV is the default and bullet-proof on any environment, it's definitely not the case for Upstart. For example, switching to it on [the official EC2 AMIs from Debian](https://wiki.debian.org/Cloud/AmazonEC2Image/Wheezy) prevents the instances to be back after a reboot. On a bare-metal install, Upstart works but some core services (resolvconf, for example) don't.

FYI, the same discussion happened for Chef 11 : https://github.com/opscode/omnibus-chef-server/pull/70