### PR TITLE
Add systemd support

### DIFF
--- a/recipes/runit.rb
+++ b/recipes/runit.rb
@@ -13,20 +13,24 @@ node.set['runit']['service_dir']  = "#{install_path}/service"
 node.set['runit']['sv_dir']       = "#{install_path}/sv"
 node.set['runit']['lsb_init_dir'] = "#{install_path}/init"
 
-case node['platform_family']
-when 'debian'
-  include_recipe 'enterprise::runit_upstart'
-when 'fedora', 'rhel'
-  case node['platform']
-  when 'amazon', 'fedora'
+if node['init_package'] == 'systemd'
+  include_recipe 'enterprise::runit_systemd'
+else
+  case node['platform_family']
+  when 'debian'
     include_recipe 'enterprise::runit_upstart'
-  else
-    if node['platform_version'] =~ /^6/
+  when 'fedora', 'rhel'
+    case node['platform']
+    when 'amazon', 'fedora'
       include_recipe 'enterprise::runit_upstart'
     else
-      include_recipe 'enterprise::runit_sysvinit'
+      if node['platform_version'] =~ /^6/
+        include_recipe 'enterprise::runit_upstart'
+      else
+        include_recipe 'enterprise::runit_sysvinit'
+      end
     end
+  else
+    include_recipe 'enterprise::runit_sysvinit'
   end
-else
-  include_recipe 'enterprise::runit_sysvinit'
 end

--- a/recipes/runit_systemd.rb
+++ b/recipes/runit_systemd.rb
@@ -1,0 +1,24 @@
+#
+# Copyright:: Copyright (c) 2015 Opscode, Inc.
+#
+# All Rights Reserved
+#
+
+project_name = node['enterprise']['name']
+unit_name = "#{project_name}-runsvdir-start.service"
+
+template "/usr/lib/systemd/system/#{unit_name}" do
+  owner "root"
+  group "root"
+  mode "0644"
+  variables({
+              :install_path => node[project_name]['install_path'],
+              :project_name => project_name
+  })
+  source "runsvdir-start.service.erb"
+end
+
+service unit_name do
+  action [:enable, :start]
+  provider Chef::Provider::Service::Systemd
+end

--- a/templates/default/runsvdir-start.service.erb
+++ b/templates/default/runsvdir-start.service.erb
@@ -1,0 +1,9 @@
+[Unit]
+Description=<%= @project_name %> Runit Process Supervisor
+
+[Service]
+ExecStart=<%= @install_path %>/embedded/bin/runsvdir-start
+Restart=always
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This is the magic sauce needed to make Chef Server install on CentOS 7 and hopefully Debian Jessie as well, though I haven't tested the latter. It doesn't need distro-specific rules because checking `node['init_package']` is sufficient to determine whether systemd is being used or not.

I'm guessing there's a reason why you're not using the regular `service` resource in the other recipes so I didn't use it here either.

I could not get the specs to run for the life of me. Some problem with the RSpec version or ChefDK? I'm not familiar with ChefSpec but I'm guessing that giving it `redhat/7.0` won't be enough for it to determine that it should use systemd.