### PR TITLE
Add test kitchen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ Berksfile.lock
 .*.sw[a-z]
 *.un~
 /cookbooks
+
+# Test Kitchen
+.kitchen/
+.kitchen.local.yml

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,0 +1,22 @@
+---
+driver:
+  name: vagrant
+
+provisioner:
+  name: chef_zero
+
+platforms:
+  - name: ubuntu-10.04
+  - name: ubuntu-12.04
+  - name: ubuntu-14.04
+  - name: centos-5.11
+  - name: centos-6.6
+  - name: centos-7.0
+
+suites:
+  - name: default
+    run_list:
+      - recipe[enterprise::runit]
+    attributes:
+      enterprise:
+        name: testproject

--- a/README.md
+++ b/README.md
@@ -30,7 +30,13 @@ In addition, you need to have:
 [ChefDK](http://downloads.chef.io/chef-dk/) must be installed (version 0.5.1 at
 the time of this writing.)
 
+### ChefSpec
+
 Run `chef exec rspec` to run ChefSpec examples.
+
+### Test Kitchen
+
+Integration tests can be run with [Test Kitchen](http://kitchen.ci/).
 
 ## License
 

--- a/recipes/runit.rb
+++ b/recipes/runit.rb
@@ -5,7 +5,7 @@
 #
 
 project_name = node['enterprise']['name']
-node.default_unless[node['enterprise']['name']] = {}
+node.default_unless[node['enterprise']['name']] = {} # ~FC047 (See https://github.com/acrmp/foodcritic/issues/225)
 install_path = node[project_name]['install_path']
 
 node.set['runit']['sv_bin']       = "#{install_path}/embedded/bin/sv"

--- a/recipes/runit.rb
+++ b/recipes/runit.rb
@@ -5,6 +5,7 @@
 #
 
 project_name = node['enterprise']['name']
+node.default_unless[node['enterprise']['name']] = {}
 install_path = node[project_name]['install_path']
 
 node.set['runit']['sv_bin']       = "#{install_path}/embedded/bin/sv"


### PR DESCRIPTION
Regular old test kitchen setup using ChefDK. The default suite runs the
runit recipe.

Also makes sure `node[node['enterprise']['name']]` is set.