### PR TITLE
Update License

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ All files in the repository are licensed under the Apache 2.0 license. If any
 file is missing the License header it should assume the following is attached;
 
 ```
-Copyright 2014-2015 Chef Software, Inc.
+Copyright 2013-2015 Chef Software, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,7 +1,7 @@
 name             'enterprise'
-license          'All rights reserved'
-description      'Installs common libraries and resources for Enterprise Chef and closed-source additions'
-long_description 'Installs common libraries and resources for Enterprise Chef and closed-source additions'
+license          'Apache 2.0'
+description      'Installs common libraries and resources for Chef server and add-ons'
+long_description 'Installs common libraries and resources for Chef server and add-ons'
 version          '0.5.2'
 
 depends          'runit', '> 1.0.0'

--- a/recipes/runit.rb
+++ b/recipes/runit.rb
@@ -1,7 +1,17 @@
 #
-# Copyright:: Copyright (c) 2013 Opscode, Inc.
+# Copyright:: Copyright (c) 2013-2015 Chef Software, Inc.
 #
-# All Rights Reserved
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 
 project_name = node['enterprise']['name']

--- a/recipes/runit_systemd.rb
+++ b/recipes/runit_systemd.rb
@@ -1,7 +1,17 @@
 #
-# Copyright:: Copyright (c) 2015 Opscode, Inc.
+# Copyright:: Copyright (c) 2015 Chef Software, Inc.
 #
-# All Rights Reserved
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 
 project_name = node['enterprise']['name']

--- a/recipes/runit_sysvinit.rb
+++ b/recipes/runit_sysvinit.rb
@@ -1,7 +1,17 @@
 #
-# Copyright:: Copyright (c) 2013 Opscode, Inc.
+# Copyright:: Copyright (c) 2015 Chef Software, Inc.
 #
-# All Rights Reserved
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 
 project_name = node['enterprise']['name']

--- a/recipes/runit_upstart.rb
+++ b/recipes/runit_upstart.rb
@@ -1,7 +1,17 @@
 #
-# Copyright:: Copyright (c) 2013 Opscode, Inc.
+# Copyright:: Copyright (c) 2015 Chef Software, Inc.
 #
-# All Rights Reserved
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 
 project_name = node['enterprise']['name'].clone


### PR DESCRIPTION
The LICENSE file and README.md had Apache 2.0, but everywhere else was
still All Rights Reserved. This makes everything copyright Chef Software
with the Apache 2.0 license.

/cc @chef/visual-interaction @chef/lob