### PR TITLE
use sysvinit for debian runsvdir

### DIFF
--- a/libraries/provider_component_runit_supervisor_sysvinit.rb
+++ b/libraries/provider_component_runit_supervisor_sysvinit.rb
@@ -4,6 +4,7 @@ class Chef
   class Provider
     class ComponentRunitSupervisor
       class Sysvinit < Chef::Provider::LWRPBase
+        provides :component_runit_supervisor, :platform => "debian"
         provides :component_runit_supervisor, :platform_family => "rhel" do |node|
           node['platform_version'].to_i == 5
         end

--- a/libraries/provider_component_runit_supervisor_upstart.rb
+++ b/libraries/provider_component_runit_supervisor_upstart.rb
@@ -4,11 +4,11 @@ class Chef
   class Provider
     class ComponentRunitSupervisor
       class Upstart < Chef::Provider::LWRPBase
-        provides :component_runit_supervisor, :platform_family => "debian"
         provides :component_runit_supervisor, :platform_family => "rhel" do |node|
           node['platform_version'].to_i == 6
         end
-        provides :component_runit_supervisor, :platform => %w[ amazon fedora ]
+        provides :component_runit_supervisor,
+          :platform => %w[ amazon fedora ubuntu ]
 
         use_inline_resources
 

--- a/spec/recipes/runit_spec.rb
+++ b/spec/recipes/runit_spec.rb
@@ -157,7 +157,7 @@ describe 'enterprise::runit' do
                                    :step_into => ["component_runit_supervisor"]
         end
 
-        it_behaves_like "upstart create"
+        it_behaves_like "sysvinit create"
       end
 
       context "when on Fedora" do


### PR DESCRIPTION
Debian defaults to sysvinit. This replaces #24. See that PR for more discussion.

/cc @chef/chef-visual-interaction