### PR TITLE
Fix use of undefined variables and add tests

### DIFF
--- a/providers/pg_user.rb
+++ b/providers/pg_user.rb
@@ -10,17 +10,10 @@ end
 use_inline_resources
 
 action :create do
-
   project_name = node['enterprise']['name']
-  connection_string = []
-  connection_string << "--host #{new_resource.host} " if  new_resource.host
-  connection_string << "--username #{new_resource.admin_username} " if  new_resource.admin_username
-  connection_string << "--password #{new_resource.admin_password} " if  new_resource.admin_password
-  connection_string = connection_string.join(" ")
 
   execute "create_postgres_user_#{new_resource.username}" do
-    command "psql --dbname template1 #{connection_string unless connection_string.empty?} \
-  --command \"#{create_user_query}\""
+    command "psql --dbname template1 #{connection_string} --command \"#{create_user_query}\""
     user node[project_name]['postgresql']['username']
     not_if {user_exist?}
     retries 30
@@ -28,18 +21,18 @@ action :create do
 end
 
 def create_user_query
-  q = ["CREATE USER #{new_resource.username} WITH"]
-  q << "SUPERUSER" if new_resource.superuser
-  q << "ENCRYPTED PASSWORD '#{new_resource.password}'"
-  q << ";"
-  q.join(" ")
+  @create_user_query ||= [].tap do |ary|
+    ary << "CREATE USER #{new_resource.username} WITH"
+    ary << "SUPERUSER" if new_resource.superuser
+    ary << "ENCRYPTED PASSWORD '#{new_resource.password}';"
+  end.join(" ")
 end
 
 def user_exist?
   project_name = node['enterprise']['name']
   command = <<-EOM.gsub(/\s+/," ").strip!
     psql --dbname template1
-         #{connection_string unless connection_string.empty?}
+         #{connection_string}
          --tuples-only
          --command "SELECT rolname FROM pg_roles WHERE rolname='#{new_resource.username}';"
     | grep #{new_resource.username}
@@ -49,4 +42,12 @@ def user_exist?
                            :user => node[project_name]['postgresql']['username'])
   s.run_command
   s.exitstatus == 0
+end
+
+def connection_string
+  @connection_string ||= [].tap do |ary|
+    ary << "--host #{new_resource.host}" if  new_resource.host
+    ary << "--username #{new_resource.admin_username}" if  new_resource.admin_username
+    ary << "--password #{new_resource.admin_password}" if  new_resource.admin_password
+  end.join(" ")
 end

--- a/spec/resources/enterprise_pg_database_spec.rb
+++ b/spec/resources/enterprise_pg_database_spec.rb
@@ -1,0 +1,43 @@
+require "spec_helper"
+
+describe "enterprise_test::enterprise_pg_database" do
+  let(:database) { "testdb" }
+  let(:encoding) { nil }
+  let(:host) { nil }
+  let(:owner) { nil }
+  let(:password) { nil }
+  let(:template) { nil }
+  let(:username) { nil }
+
+  let(:runner) do
+    ChefSpec::SoloRunner.new :step_into => ["enterprise_pg_database"] do |node|
+      node.default['testproject']['postgresql']['username'] = "testuser"
+      node.default['test']['database'] = database
+      node.default['test']['encoding'] = encoding
+      node.default['test']['host'] = host
+      node.default['test']['owner'] = owner
+      node.default['test']['password'] = password
+      node.default['test']['template'] = template
+      node.default['test']['username'] = username
+    end
+  end
+  subject(:chef_run) { runner.converge(described_recipe) }
+
+  it "creates a database" do
+    expect(chef_run).to run_execute("create_database_testdb")
+  end
+
+  context "when a username, host, and password are present" do
+    let(:username) { "testdbuser" }
+    let(:password) { "testpass" }
+    let(:host) { "testhost"  }
+
+    it "uses the username, host, and password" do
+      expect(chef_run).to run_execute("create_database_testdb").with(
+        :command => "createdb --template template0 --encoding UTF-8 --host testhost --username testdbuser --password testpass testdb",
+        :user => "testuser",
+        :retries => 30,
+      )
+    end
+  end
+end

--- a/spec/resources/enterprise_pg_user_spec.rb
+++ b/spec/resources/enterprise_pg_user_spec.rb
@@ -1,0 +1,40 @@
+require "spec_helper"
+
+describe "enterprise_test::enterprise_pg_user" do
+  let(:admin_password) { nil }
+  let(:admin_username) { nil }
+  let(:host) { nil }
+  let(:password) { "testpass" }
+  let(:superuser) { nil }
+
+  let(:runner) do
+    ChefSpec::SoloRunner.new :step_into => ["enterprise_pg_user"] do |node|
+      node.default['testproject']['postgresql']['username'] = "testuser"
+      node.default['test']['admin_password'] = admin_password
+      node.default['test']['admin_username'] = admin_username
+      node.default['test']['host'] = host
+      node.default['test']['password'] = password
+      node.default['test']['superuser'] = superuser
+    end
+  end
+
+  subject(:chef_run) { runner.converge(described_recipe) }
+
+  it "creates a user" do
+    expect(chef_run).to run_execute("create_postgres_user_testuser")
+  end
+
+  context "when a username, host, and password are present" do
+    let(:admin_username) { "testadminuser" }
+    let(:admin_password) { "testadminpass" }
+    let(:host) { "testhost"  }
+
+    it "uses the username, host, and password" do
+      expect(chef_run).to run_execute("create_postgres_user_testuser").with(
+        :command => "psql --dbname template1 --host testhost --username testadminuser --password testadminpass --command \"CREATE USER testuser WITH ENCRYPTED PASSWORD 'testpass';\"",
+        :user => "testuser",
+        :retries => 30,
+      )
+    end
+  end
+end

--- a/test/fixtures/cookbooks/enterprise_test/recipes/enterprise_pg_database.rb
+++ b/test/fixtures/cookbooks/enterprise_test/recipes/enterprise_pg_database.rb
@@ -1,0 +1,10 @@
+node.default['enterprise']['name'] = "testproject"
+
+enterprise_pg_database node['test']['database'] do
+  encoding node['test']['encoding']
+  host node['test']['host']
+  owner node['test']['owner']
+  password node['test']['password']
+  username node['test']['username']
+  template node['test']['template']
+end

--- a/test/fixtures/cookbooks/enterprise_test/recipes/enterprise_pg_user.rb
+++ b/test/fixtures/cookbooks/enterprise_test/recipes/enterprise_pg_user.rb
@@ -1,0 +1,9 @@
+node.default['enterprise']['name'] = "testproject"
+
+enterprise_pg_user "testuser" do
+  admin_password node['test']['admin_password']
+  admin_username node['test']['admin_username']
+  host node['test']['host']
+  password node['test']['password']
+  superuser node['test']['superuser']
+end


### PR DESCRIPTION
In the pg database and user resources a `connection_string` variable was
being referenced that was not defined in the correct places. This fixes
that by extracting it out into a method and adds ChefSpec tests for
basic verification of the command output.

Passing the `--password` flag to `createdb` does not actually work how
the code expects. These commits do not fix that, but leave the behavior
as was intended in the original code. Another PR will be needed to fix
that.

Replaces #37. Fixes #36.